### PR TITLE
GS29-Heading más chato

### DIFF
--- a/Marketplace/public/css/common/site-header.css
+++ b/Marketplace/public/css/common/site-header.css
@@ -8,7 +8,7 @@
 }
     
 main {
-    margin-top: 190px;
+    margin-top: 130px;
 }
 
 .top-header {
@@ -24,7 +24,7 @@ main {
 #profile-container {
     justify-content: center;
     align-content: center;
-    width: 14%;
+    width: 20%;
 }
 
 #logo-container {

--- a/Marketplace/public/css/common/site-responsive.css
+++ b/Marketplace/public/css/common/site-responsive.css
@@ -11,8 +11,7 @@
     }
 
     #menu-button-container {
-        width: 100%;
-        order: 5;
+        flex-wrap: nowrap;
         justify-content: flex-start;
         padding-top: 1em;
         padding-left: 2em;
@@ -20,6 +19,7 @@
     
     #menu-button {
         font-size: 2em;
+        margin-right: 30px;
     }
 
     #nav-bar,
@@ -29,7 +29,7 @@
 
     #nav-bar {
         width: 95%;
-        padding-left: 2em;
+        
         display: flex;
         flex-wrap: wrap;
         align-content: center;
@@ -50,7 +50,7 @@
     }
 
     #search-container {
-        width: 60%;
+        width: 30%;
     }
     
     #shop-cart-container,

--- a/Marketplace/public/css/common/site.css
+++ b/Marketplace/public/css/common/site.css
@@ -25,3 +25,8 @@ body {
     display: flex;
     flex-wrap: wrap;
 }
+
+.flex-col {
+    display: flex;
+    flex-direction: column;
+}

--- a/Marketplace/views/partials/header.ejs
+++ b/Marketplace/views/partials/header.ejs
@@ -4,9 +4,9 @@
             <i class="fa fa-bars burger"></i>
         </button>
         <div id="nav-bar">
-            <ul id="menu" class="flex-container">
-                <li><a href="#" class="menu-options">Guitarras electricas</a></li>
-                <li><a href="#" class="menu-options">Guitarras acusticas</a></li>
+            <ul id="menu" class="flex-container flex-col">
+                <li><a href="#" class="menu-options">Guitarras eléctricas</a></li>
+                <li><a href="#" class="menu-options">Guitarras acústicas</a></li>
                 <li><a href="#" class="menu-options">Bajos</a></li>
                 <li><a href="#" class="menu-options">Teclados</a></li>
             </ul>


### PR DESCRIPTION
El heading quedó en 1 sola fila. Ocupa menos lugar sin perder funcionalidad.
También corregí la ortografía de los títulos (puse los tildes)