### PR TITLE
SP08-1 Correcciones en eliminar usuario

### DIFF
--- a/Marketplace/controllers/userController.js
+++ b/Marketplace/controllers/userController.js
@@ -105,7 +105,7 @@ module.exports = {
 		res.redirect("/usuario/detalle");
 	},
 	eliminar: async (req, res) => {
-		await EliminarUsuario(req.session.usuarioLogeado.id);
+		await usuarioRepository.Eliminar(req.session.usuarioLogeado.id);
 		res.redirect("/usuario/logout");
 	},
 	loginForm: (req, res) => {
@@ -139,12 +139,6 @@ module.exports = {
 		return res.redirect("/");
 	}
 };
-
-async function EliminarUsuario(id) {
-	let avatar = await usuarioRepository.ObtenerAvatar(id);
-	await usuarioRepository.Eliminar(id);
-	BorrarArchivoDeImagen(avatar);
-}
 
 function BorrarArchivoDeImagen(nombreDeArchivo) {
 	let imageFile = path.join(imagesPath, nombreDeArchivo);

--- a/Marketplace/controllers/userController.js
+++ b/Marketplace/controllers/userController.js
@@ -105,8 +105,8 @@ module.exports = {
 		res.redirect("/usuario/detalle");
 	},
 	eliminar: async (req, res) => {
-		let imagen = await usuarioRepository.ObtenerPorId(req.session.usuarioLogeado.id).then(n => n.avatar)
-		BorrarArchivoDeImagen(imagen);
+		let avatar = await usuarioRepository.ObtenerPorId(req.session.usuarioLogeado.id).then(n => n.avatar)
+		BorrarArchivoDeImagen(avatar);
 		await usuarioRepository.Eliminar(req.session.usuarioLogeado.id);
 		res.redirect("/usuario/logout");
 	},

--- a/Marketplace/controllers/userController.js
+++ b/Marketplace/controllers/userController.js
@@ -105,6 +105,8 @@ module.exports = {
 		res.redirect("/usuario/detalle");
 	},
 	eliminar: async (req, res) => {
+		let imagen = await usuarioRepository.ObtenerPorId(req.session.usuarioLogeado.id).then(n => n.avatar)
+		BorrarArchivoDeImagen(imagen);
 		await usuarioRepository.Eliminar(req.session.usuarioLogeado.id);
 		res.redirect("/usuario/logout");
 	},
@@ -142,7 +144,5 @@ module.exports = {
 
 function BorrarArchivoDeImagen(nombreDeArchivo) {
 	let imageFile = path.join(imagesPath, nombreDeArchivo);
-	if (nombreDeArchivo && fs.existsSync(imageFile)) {
-		fs.unlinkSync(imageFile);
-	}
+	nombreDeArchivo && fs.existsSync(imageFile) ? fs.unlinkSync(imageFile) : "";
 }

--- a/Marketplace/repositories/usuarioRepository.js
+++ b/Marketplace/repositories/usuarioRepository.js
@@ -2,6 +2,9 @@ const { Op } = require("sequelize");
 const bcryptjs = require("bcryptjs");
 const db = require("../database/models");
 const entidad = db.Usuario;
+const fs = require("fs");
+const path = require("path");
+const imagesPath = path.join(__dirname, "../public/images/users/");
 
 module.exports = {
 	ObtenerTodos: () => {
@@ -48,18 +51,24 @@ module.exports = {
 			where: { id: id },
 		});
 	},
-	Eliminar: (id, usuario) => {
+	Eliminar: (usuarioId) => {
+		entidad
+			.findByPk(usuarioId)
+			.then((n) => n.avatar)
+			.then((n) => BorrarArchivoDeImagen(n));
 		return entidad.update({
 			borrado: true,
-			actualizado_por: usuario
-		},
+			actualizado_por: usuarioId
+		}, 
 		{
-			where: { id: id },
+			where: { id: usuarioId },
 		});
 	},
-	ObtenerAvatar: async (id) => {
-		let usuario = await entidad.findByPk(id);
-
-		return usuario.avatar;
-	}
 };
+
+function BorrarArchivoDeImagen(nombreDeArchivo) {
+	let imageFile = path.join(imagesPath, nombreDeArchivo);
+	if (nombreDeArchivo && fs.existsSync(imageFile)) {
+		fs.unlinkSync(imageFile);
+	}
+}

--- a/Marketplace/repositories/usuarioRepository.js
+++ b/Marketplace/repositories/usuarioRepository.js
@@ -9,20 +9,20 @@ module.exports = {
 	},
 	ObtenerPorId: (id) => {
 		return entidad.findByPk(id, {
-			include: [ "roles" ]
+			include: ["roles"],
 		});
 	},
 	ObtenerPorEmail: (email) => {
 		return entidad.findOne({
-			where: {email: email}
+			where: { email: email },
 		});
 	},
 	EmailYaExistente: async (email, id) => {
 		let cantidad = await entidad.count({
 			where: {
-				id: {[Op.ne]: id},
+				id: { [Op.ne]: id },
 				email: email,
-			}
+			},
 		});
 		return cantidad > 0;
 	},
@@ -33,29 +33,31 @@ module.exports = {
 			email: infoUsuario.email,
 			contrasena: bcryptjs.hashSync(infoUsuario.contrasena, 10),
 			avatar: fileName,
-			rol_id: 2
+			rol_id: 2,
 		});
 	},
 	Actualizar: (id, infoUsuario, fileName) => {
-		return entidad.update({
-			nombre: infoUsuario.nombre,
-			apellido: infoUsuario.apellido,
-			email: infoUsuario.email,
-			contrasena: bcryptjs.hashSync(infoUsuario.contrasena, 10),
-			avatar: fileName
-		},
-		{
-			where: { id: id },
-		});
+		return entidad.update(
+			{
+				nombre: infoUsuario.nombre,
+				apellido: infoUsuario.apellido,
+				email: infoUsuario.email,
+				contrasena: bcryptjs.hashSync(infoUsuario.contrasena, 10),
+				avatar: fileName,
+			},
+			{
+				where: { id: id },
+			}
+		);
 	},
 	Eliminar: (usuarioId) => {
 		return entidad.update(
 			{
-				borrado: true, 
-				actualizado_por: usuarioId
+				borrado: true,
+				actualizado_por: usuarioId,
 			},
 			{
-				where: { id: usuarioId }
+				where: { id: usuarioId },
 			}
 		);
 	},

--- a/Marketplace/repositories/usuarioRepository.js
+++ b/Marketplace/repositories/usuarioRepository.js
@@ -50,8 +50,13 @@ module.exports = {
 	},
 	Eliminar: (usuarioId) => {
 		return entidad.update(
-			{borrado: true, actualizado_por: usuarioId},
-			{where: { id: usuarioId }}
+			{
+				borrado: true, 
+				actualizado_por: usuarioId
+			},
+			{
+				where: { id: usuarioId }
+			}
 		);
 	},
 };

--- a/Marketplace/repositories/usuarioRepository.js
+++ b/Marketplace/repositories/usuarioRepository.js
@@ -59,7 +59,7 @@ module.exports = {
 		return entidad.update({
 			borrado: true,
 			actualizado_por: usuarioId
-		}, 
+		},
 		{
 			where: { id: usuarioId },
 		});
@@ -68,7 +68,5 @@ module.exports = {
 
 function BorrarArchivoDeImagen(nombreDeArchivo) {
 	let imageFile = path.join(imagesPath, nombreDeArchivo);
-	if (nombreDeArchivo && fs.existsSync(imageFile)) {
-		fs.unlinkSync(imageFile);
-	}
+	nombreDeArchivo && fs.existsSync(imageFile) ? fs.unlinkSync(imageFile) : ""
 }

--- a/Marketplace/repositories/usuarioRepository.js
+++ b/Marketplace/repositories/usuarioRepository.js
@@ -2,9 +2,6 @@ const { Op } = require("sequelize");
 const bcryptjs = require("bcryptjs");
 const db = require("../database/models");
 const entidad = db.Usuario;
-const fs = require("fs");
-const path = require("path");
-const imagesPath = path.join(__dirname, "../public/images/users/");
 
 module.exports = {
 	ObtenerTodos: () => {
@@ -52,21 +49,9 @@ module.exports = {
 		});
 	},
 	Eliminar: (usuarioId) => {
-		entidad
-			.findByPk(usuarioId)
-			.then((n) => n.avatar)
-			.then((n) => BorrarArchivoDeImagen(n));
-		return entidad.update({
-			borrado: true,
-			actualizado_por: usuarioId
-		},
-		{
-			where: { id: usuarioId },
-		});
+		return entidad.update(
+			{borrado: true, actualizado_por: usuarioId},
+			{where: { id: usuarioId }}
+		);
 	},
 };
-
-function BorrarArchivoDeImagen(nombreDeArchivo) {
-	let imageFile = path.join(imagesPath, nombreDeArchivo);
-	nombreDeArchivo && fs.existsSync(imageFile) ? fs.unlinkSync(imageFile) : ""
-}


### PR DESCRIPTION
En el proceso de eliminar usuario, había una inconsistencia de parámetros entre la **función eliminar** y el **método eliminar del repositorio**.
    - La función EliminarUsuario tenía un sólo parámetro --> await usuarioRepository.Eliminar(id);
    - El método Eliminar del repositorio de usuario, tenía 2 parámetros --> Eliminar: (id, usuario)
Esta situación está resuelta en este ticket. Por el momento, se dejó un sólo parámetro porque ambos coinciden, con la opción de eliminar que tenemos en la vista actual.

De paso, se simplificó el proceso de la siguiente manera:
1. Se movió la _función eliminar_ al controlador. Se usaba solamente para este método y eran 3 líneas de comando.
2. Se eliminó el _método obtener avatar_ del repositorio, que se usaba únicamente para asistir a la función eliminar. Se la incorporó al _método eliminar_ del controlador, anexando un mínimo código a una línea.
De esa manera, se concentraron 3 bloques de código en uno sólo.