### PR TITLE
Iconos de Google y Facebook quitados de Crear/Editar

### DIFF
--- a/Marketplace/views/users/usuario-crear-y-editar.ejs
+++ b/Marketplace/views/users/usuario-crear-y-editar.ejs
@@ -156,16 +156,7 @@
 			<section id="boton-registro">
 				<button class="button" type="submit">Envíe los datos</button>
 				<div class="contenedor-redes">
-					<a href="https://www.facebook.com/">
-						<button class="redes-sociales">
-							<i class="fab fa-facebook-square"></i>
-						</button>
-					</a>
-					<a href="https://accounts.google.com/">
-						<button class="redes-sociales">
-							<i class="fab fa-google"></i>
-						</button>
-					</a>
+					<button class="redes-sociales"></button>
 				</div>    
 			</section>
 


### PR DESCRIPTION
Se quitaron los íconos de Google y Facebook de la vista de Crear/Editar usuario